### PR TITLE
add: exclude file support

### DIFF
--- a/bin/tempest-report
+++ b/bin/tempest-report
@@ -66,6 +66,9 @@ Examples:
                       default=os.environ.get('OS_REGION_NAME'),
                       help='Openstack tenant name. '
                            'Defaults to env[OS_REGION_NAME].')
+    parser.add_option('-e', '--exclude', dest="exclude",
+                      help='file with a list of regex of test to exclude.')
+
     parser.add_option('-r', '--release', default=sys.maxint,
                       dest="max_release_level",
                       help='Only run tests with a release lower or equal.'

--- a/exclude.example
+++ b/exclude.example
@@ -1,0 +1,5 @@
+# Disable one specific test
+test_cinder.SimpleReadOnlyCinderClientTest.test_cinder_service_list
+
+# Disable multiple tests
+test_vpnaas_extensions


### PR DESCRIPTION
This patch allow to run tempest-report with --full-run option and to
provide an exclude file where some tests won't be run.

So it add an --exclude option where we have to specify an exclude file.

Example of use:
tempest-report --full-run --exclude my_exclude_tests
## Syntax of exclude file:

test_create_server
test_virtual_interfaces.VirtualInterfacesTestJSON
test_nova_manage.SimpleReadOnlyNovaManageTest.test_cell_list

Co-Authored-by: Mehdi Abaakouk mehdi.abaakouk@enovance.com
