### PR TITLE
Allow to generate a report in junit format

### DIFF
--- a/bin/tempest-report
+++ b/bin/tempest-report
@@ -68,7 +68,8 @@ Examples:
                            'Defaults to env[OS_REGION_NAME].')
     parser.add_option('-e', '--exclude', dest="exclude",
                       help='file with a list of regex of test to exclude.')
-
+    parser.add_option('--junit', dest="junit",
+                      help="Write the result to the JUNIT file in junit format.")
     parser.add_option('-r', '--release', default=sys.maxint,
                       dest="max_release_level",
                       help='Only run tests with a release lower or equal.'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-novaclient
 -e git://github.com/openstack/tempest.git#egg=tempest
 python-ceilometerclient
 requests
+junit-xml-output


### PR DESCRIPTION
This change allows to generate a report in junit format
by passing the parameter --junit <myreport.xml>.
