### PR TITLE
Add tox/testr configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
+.testrepository
+.tox
 status.db
+*.egg-info

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,0 +1,7 @@
+[DEFAULT]
+test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
+             OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
+             OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-600} \
+             ${PYTHON:-python} -m subunit.run discover tests $LISTOPT $IDOPTION
+test_id_option=--load-list $IDFILE
+test_list_option=--list

--- a/tempest_report/utils.py
+++ b/tempest_report/utils.py
@@ -39,6 +39,9 @@ from tempest_report import settings
 
 def load_excluded_tests(fname):
     """ Load the excluded tests form a flat file."""
+    if not fname:
+        return []
+
     regexps = []
     with open(fname) as excluded_tests:
         for line in excluded_tests:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,5 @@
+coverage>=3.6
+discover
 mock>=1.0
+python-subunit>=0.0.18
+testrepository>=0.0.18

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+minversion = 1.6
+skipsdist = True
+envlist = py27,pep8
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+usedevelop = True
+commands = python setup.py testr --slowest --testr-args="{posargs}"
+downloadcache = {toxworkdir}/_download
+whitelist_externals = bash
+
+[testenv:cover]
+commands = python setup.py testr --slowest --coverage --testr-args="{posargs}"
+
+[testenv:pep8]
+commands = flake8
+
+[testenv:venv]
+commands = {posargs}
+
+[flake8]
+builtins = _
+exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,tools,nova_tests,build
+show-source = True


### PR DESCRIPTION
This change adds tox and testr configuration.

And it also fixes all the unit tests.

Now the test suite can be run with:

$ tox -epy27
