### PR TITLE
Remove junit_xml_output dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ python-novaclient
 -e git://github.com/openstack/tempest.git#egg=tempest
 python-ceilometerclient
 requests
-junit-xml-output

--- a/tempest_report/utils.py
+++ b/tempest_report/utils.py
@@ -28,8 +28,8 @@ import subprocess
 import tempfile
 import threading
 import time
+from xml.sax import saxutils
 
-import junit_xml_output
 import keystoneclient
 import tempest
 
@@ -90,6 +90,24 @@ def delete_tenant_and_user(username, password, auth_url, tenant_name, user):
                                                  tenant_name=tenant_name)
     keystone.users.delete(user['user_id'])
     keystone.tenants.delete(user['tenant_id'])
+
+
+def gen_junit_file(filepath, title, tests):
+    failures = len(filter(lambda x: not x[2], tests))
+
+    with open(filepath, "w") as f:
+        f.write('<testsuite failures="%d" name="%s"" tests="%s">\n' %
+                     (failures, title, len(tests)))
+        for testname, output, status in tests:
+            if status:
+                f.write('    <testcase name="%s"/>\n' % testname)
+            else:
+                f.write('    <testcase name="%s">\n' % testname)
+                f.write('        <failure>\n')
+                f.write(saxutils.escape(output))
+                f.write('        </failure>\n')
+                f.write('    </testcase>\n')
+        f.write('</testsuite>\n')
 
 
 """ Methods to create a summary of the tests """
@@ -179,8 +197,7 @@ def worker(queue, successful_tests, successful_subtests, junit_tests,
             break
 
         success, output = executer(testname, configfile_name)
-        junit_tests.append(junit_xml_output.TestCase(
-            testname, output, "success" if success else "failure"))
+        junit_tests.append((testname, output, success))
 
         logger.debug(output)
 
@@ -343,6 +360,4 @@ def main(options):
     if options.junit:
         print "Writting junit test reports to %s" % options.junit
         junit_title = "tempest-report (%s)" % now.strftime("%Y%m%d-%H%M%S")
-        with open(options.junit, "w") as junit_file:
-            junit_xml = junit_xml_output.JunitXml(junit_title, junit_tests)
-            junit_file.write(junit_xml.dump())
+        gen_junit_file(options.junit, junit_title, junit_tests)


### PR DESCRIPTION
Hi,

junit_xml_output is not packaged on debian/ubuntu/RHEL, so we build our own xml file instead of this dep.

Cheers,
